### PR TITLE
Rename possum references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Removed hard dependency on older version of `rest-client` gem.
 
-# v5.0.0
+# v5.0.0-beta.1
 
 * Migrated to be compatible with Conjur 5 API.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,6 @@ COPY lib/conjur-api/version.rb ./lib/conjur-api/
 RUN bundle
 
 COPY . ./
+
+ENTRYPOINT ["/usr/local/bin/bundle", "exec"]
+CMD ["rake", "jenkins"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,17 @@ pipeline {
         junit 'features/reports/*.xml'
       }
     }
+  }
 
+  post {
+    always {
+      sh 'docker run -i --rm -v $PWD:/src -w /src alpine/git clean -fxd'
+    }
+    failure {
+      slackSend(color: 'danger', message: "${env.JOB_NAME} #${env.BUILD_NUMBER} FAILURE (<${env.BUILD_URL}|Open>)")
+    }
+    unstable {
+      slackSend(color: 'warning', message: "${env.JOB_NAME} #${env.BUILD_NUMBER} UNSTABLE (<${env.BUILD_URL}|Open>)")
+    }
   }
 }

--- a/ci/setup-account.sh
+++ b/ci/setup-account.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -e
-
-for i in $(seq 10); do
-	curl -o /dev/null -fs -X OPTIONS http://localhost > /dev/null && break
-	echo -n "." 1>&2
-	sleep 2
-done
-
-possum account create cucumber

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -ex
-
-for i in $(seq 10); do
-	curl -o /dev/null -fs -X OPTIONS http://possum > /dev/null && break || exit 1
-	echo -n "."
-	sleep 2
-done
-
-bundle exec ${@-rake jenkins} || true

--- a/ci/wait_for_server.sh
+++ b/ci/wait_for_server.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -e
 
-for i in $(seq 20); do
-  curl -o /dev/null -fs -X OPTIONS http://possum > /dev/null && break
+for _ in $(seq 20); do
+  curl -o /dev/null -fs -X OPTIONS http://conjur > /dev/null && break
   echo .
   sleep 2
 done
 
 # So we fail if the server isn't up yet:
-curl -o /dev/null -fs -X OPTIONS http://possum > /dev/null
+curl -o /dev/null -fs -X OPTIONS http://conjur > /dev/null

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,26 +1,23 @@
-pg:
-  image: postgres:9.3
-  
-possum:
-  image: possum
-  command: server -a cucumber -f /run/empty.yml
-  environment:
-    DATABASE_URL: postgres://postgres@pg/postgres
-    POSSUM_ADMIN_PASSWORD: admin
-    POSSUM_DATA_KEY:
-  volumes:
-  - ./empty.yml:/run/empty.yml:ro
-  links:
-  - pg:pg
+version: '2'
+services:
+  postgres:
+    image: postgres:9.3
 
-cli:
-  build: ..
-  entrypoint: sleep
-  command: infinity
-  environment:
-    CONJUR_APPLIANCE_URL: http://possum
-    CONJUR_ACCOUNT: cucumber
-  volumes:
-  - ..:/src/conjur-api
-  links:
-  - possum:possum
+  conjur:
+    command: server -a cucumber -f /run/empty.yml
+    environment:
+      DATABASE_URL: postgres://postgres@pg/postgres
+      CONJUR_ADMIN_PASSWORD: admin
+      CONJUR_DATA_KEY:
+    volumes:
+    - ./empty.yml:/run/empty.yml:ro
+
+  conjur-cli:
+    build: ..
+    entrypoint: sleep
+    command: infinity
+    environment:
+      CONJUR_APPLIANCE_URL: http://conjur
+      CONJUR_ACCOUNT: cucumber
+    volumes:
+      - ..:/src/conjur-api-ruby

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -6,10 +6,10 @@ docker-compose build
 
 if [ ! -f data_key ]; then
 	echo "Generating data key"
-	docker-compose run --no-deps --rm --entrypoint possum possum data-key generate > data_key
+	docker-compose run --no-deps --rm --entrypoint conjur conjurctl data-key generate > data_key
 fi
 
-export POSSUM_DATA_KEY="$(cat data_key)"
+export CONJUR_DATA_KEY="$(cat data_key)"
 
 docker-compose up -d
 docker-compose exec cli bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,12 @@ services:
   postgres:
     image: postgres:9.3
 
-  possum:
+  conjur:
     image: registry.tld/possum:0.1.0-stable
     command: server -a cucumber
     environment:
       DATABASE_URL: postgres://postgres@postgres/postgres
-      POSSUM_DATA_KEY: 'WMfApcDBtocRWV+ZSUP3Tjr5XNU+Z2FdBb6BEezejIs='
+      CONJUR_DATA_KEY: 'WMfApcDBtocRWV+ZSUP3Tjr5XNU+Z2FdBb6BEezejIs='
     depends_on:
       - postgres
     # healthcheck:
@@ -17,13 +17,11 @@ services:
     #   timeout: 1s
     #   retries: 5
 
-  test:
+  tester:
     build: .
-    depends_on:
-      - possum
     volumes:
       - ./spec/reports:/src/conjur-api/spec/reports
       - ./features/reports:/src/conjur-api/features/reports
     environment:
-      CONJUR_APPLIANCE_URL: http://possum
+      CONJUR_APPLIANCE_URL: http://conjur
       CONJUR_ACCOUNT: cucumber

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,3 +1,0 @@
-#!/bin/bash -ex
-
-./test.sh


### PR DESCRIPTION
Build is green here: https://jenkins.conjur.net/view/Conjur%205.x/job/cyberark--conjur-api-ruby/job/rename-possum-references/

I think we should create a new issue to get this released as 5.0.0. Closes #112.