### PR TITLE
Adds a promotion step for pushing conjur-api-ruby to RubyGems

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,12 @@ pipeline {
       }
     }
 
+    stage('Debug PUBLISH env var') {
+      steps {
+        sh 'printenv'
+      }
+    }
+
     stage('Publishing to RubyGems') {
       when {
         branch 'master'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,39 +19,38 @@ pipeline {
       }
     }
 
-
+    // Only publish to RubyGems if branch is 'master'
+    // AND someone confirms this stage within 5 minutes
     stage('Publish to RubyGems') {
       when {
-        // Only publish to RubyGems if branch is 'master'
-        // AND someone confirms this stage within 1 minute.
         allOf {
-          branch 'debug-env-var-jenkins'
-          // branch 'master'
-
+          branch 'master'
           expression {
             boolean publish = false
+
             if (env.PUBLISH_GEM == "true") {
                 return true
             }
+
             try {
-              timeout(time: 1, unit: 'MINUTES') {
+              timeout(time: 5, unit: 'MINUTES') {
                 input(message: 'Publish to RubyGems?')
                 publish = true
               }
             } catch (final ignore) {
               publish = false
             }
+
             return publish
           }
         }
       }
       steps {
         milestone(2)
-        echo 'promoting!'
-        // build(job: 'release-rubygems', parameters: [
-        //   string(name: 'GEM_NAME', value: 'conjur-api'),
-        //   string(name: 'GEM_BRANCH', value: "${env.BRANCH_NAME}")
-        // ])
+        build(job: 'release-rubygems', parameters: [
+          string(name: 'GEM_NAME', value: 'conjur-api'),
+          string(name: 'GEM_BRANCH', value: "${env.BRANCH_NAME}")
+        ])
         milestone(3)
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
 
     // Only publish to RubyGems if branch is 'master'
     // AND someone confirms this stage within 5 minutes
-    stage('Publish to RubyGems') {
+    stage('Publish to RubyGems?') {
       when {
         allOf {
           branch 'master'


### PR DESCRIPTION
I just need a visual check. I'll take care of any releasebot issues if they come up. Once we have this first `pre` pushing from master we can refine this more.

Take note of `stage('Publish to RubyGems?')` in this PR - instead of relying on the buggy and intrusive jenkins promotion plugins we can use `input` like this for promotions. It's a little verbose, but maybe we could wrap this into a nice simple pipeline library function later on?