### PR TITLE
Leverage `publish-rubygems` image to build and publish gem

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,12 +46,7 @@ pipeline {
         }
       }
       steps {
-        milestone(2)
-        build(job: 'release-rubygems', parameters: [
-          string(name: 'GEM_NAME', value: 'conjur-api'),
-          string(name: 'GEM_BRANCH', value: "${env.BRANCH_NAME}")
-        ])
-        milestone(3)
+        sh './publish.sh'
       }
     }
   }

--- a/publish.sh
+++ b/publish.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+docker pull registry.tld/conjurinc/publish-rubygem
+
 summon --yaml "RUBYGEMS_API_KEY: !var rubygems/api-key" \
   docker run --rm --env-file @SUMMONENVFILE -v "$(pwd)":/opt/src \
   registry.tld/conjurinc/publish-rubygem conjur-api

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+summon --yaml "RUBYGEMS_API_KEY: !var rubygems/api-key" \
+  docker run --rm --env-file @SUMMONENVFILE -v "$(pwd)":/opt/src \
+  registry.tld/conjurinc/publish-rubygem conjur-api


### PR DESCRIPTION
#### What does this PR do?
Uses the image created in this PR: https://github.com/conjurinc/publish-rubygem/pull/1 to build and publish a gem as part of a locally managed `publish.sh` step.

#### Where should the reviewer start?
`publish.sh` has the heavy lifting.

#### How should this be manually tested?
This PR is hard to manually test due to the fact that it requires access to the API key. 

#### Any background context you want to provide?
As I understand Jenkin's Pipelines, this approach enables a developer to run more steps locally (assuming API credential access), which is desired.

#### What are the relevant tickets?
Fixes [#188](https://github.com/cyberark/conjur/issues/188)

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur-api-ruby/job/pipeline-publishing/

Please note this publish step only runs against the master branch.

#### Reviewers
@dustinmm80 