### PR TITLE
Add special handling for some v4 / v5 object field differences

### DIFF
--- a/features_v4/resource_fields.feature
+++ b/features_v4/resource_fields.feature
@@ -1,0 +1,47 @@
+Feature: Display basic resource fields.
+
+  Scenario: Group exposes id, kind, identifier, and gidnumber.
+    When I run the code:
+    """
+    resource = $conjur.resource('cucumber:group:developers')
+    [ resource.id, resource.account, resource.kind, resource.identifier, resource.gidnumber ]
+    """
+    Then the JSON should be:
+    """
+    [
+      "cucumber:group:developers",
+      "cucumber",
+      "group",
+      "developers",
+      2000
+    ]
+    """
+
+  Scenario: User exposes id, kind, identifier, and uidnumber.
+    When I run the code:
+    """
+    resource = $conjur.resource('cucumber:user:alice')
+    [ resource.id, resource.account, resource.kind, resource.identifier, resource.uidnumber ]
+    """
+    Then the JSON should be:
+    """
+    [
+      "cucumber:user:alice",
+      "cucumber",
+      "user",
+      "alice",
+      2000
+    ]
+    """
+
+  Scenario: Resource#owner is the owner object
+    When I run the code:
+    """
+    $conjur.resource('cucumber:group:developers').owner.id
+    """
+    Then the result should be "cucumber:group:security_admin"
+    And I run the code:
+    """
+    $conjur.resource('cucumber:group:developers').class
+    """
+    Then the result should be "Conjur::Group"

--- a/features_v4/support/policy.yml
+++ b/features_v4/support/policy.yml
@@ -1,6 +1,10 @@
-- !user alice
-
-- !group developers
+- !user
+  id: alice
+  uidnumber: 2000
+  
+- !group
+  id: developers
+  gidnumber: 2000
 
 - !group everyone
 
@@ -11,6 +15,11 @@
 - !variable db-password
 
 - !variable ssh-key
+
+- !variable
+  id: ssl-certificate
+  kind: SSL certificate
+  mime_type: application/x-pem-file
 
 - !layer myapp
 

--- a/features_v4/variable_fields.feature
+++ b/features_v4/variable_fields.feature
@@ -1,0 +1,11 @@
+Feature: Display Variable fields.
+
+  Background:
+    When I run the code:
+    """
+    $conjur.resource('cucumber:variable:ssl-certificate')
+    """
+
+  Scenario: Display MIME type and kind
+    Then the JSON at "mime_type" should be "application/x-pem-file"
+    And the JSON at "kind" should be "SSL certificate"

--- a/features_v4/variable_value.feature
+++ b/features_v4/variable_value.feature
@@ -31,7 +31,7 @@ Feature: Work with Variable values.
     """
     When I run the code:
     """
-    @variable.value(1)
+    @variable.value(@variable.version_count - 2)
     """
     Then the result should be "value-0"
 

--- a/lib/conjur/api/router/v4.rb
+++ b/lib/conjur/api/router/v4.rb
@@ -91,6 +91,37 @@ module Conjur
           RestClient::Resource.new(Conjur.configuration.core_url, credentials)['variables']['values'][options_querystring options]
         end
 
+        def group_attributes credentials, resource, id
+          verify_account(id.account)
+          JSON.parse(RestClient::Resource.new(Conjur.configuration.core_url, credentials)['groups'][fully_escape id.identifier].get)
+        end
+
+        def variable_attributes credentials, resource, id
+          verify_account(id.account)
+          JSON.parse(RestClient::Resource.new(Conjur.configuration.core_url, credentials)['variables'][fully_escape id.identifier].get)
+        end
+
+        def user_attributes credentials, resource, id
+          verify_account(id.account)
+          JSON.parse(RestClient::Resource.new(Conjur.configuration.core_url, credentials)['users'][fully_escape id.identifier].get)
+        end
+
+        def parse_group_gidnumber attributes
+          attributes['gidnumber']
+        end
+
+        def parse_user_uidnumber attributes
+          attributes['uidnumber']
+        end
+
+        def parse_variable_kind attributes
+          attributes['kind']
+        end
+
+        def parse_variable_mime_type attributes
+          attributes['mime_type']
+        end
+
         def parse_members credentials, result
           result.collect do |json|
             RoleGrant.parse_from_json(json, credentials)

--- a/lib/conjur/api/router/v5.rb
+++ b/lib/conjur/api/router/v5.rb
@@ -97,10 +97,44 @@ module Conjur
           RestClient::Resource.new(Conjur.configuration.core_url, credentials)['secrets'][options_querystring(options).gsub("%2C", ',')]
         end
 
+        def group_attributes credentials, resource, id
+          resource_annotations resource
+        end
+
+        def variable_attributes credentials, resource, id
+          resource_annotations resource
+        end
+
+        def user_attributes credentials, resource, id
+          resource_annotations resource
+        end
+
+        def parse_group_gidnumber attributes
+          HasAttributes.annotation_value attributes, 'conjur/gidnumber'
+        end
+
+        def parse_user_uidnumber attributes
+          HasAttributes.annotation_value attributes, 'conjur/uidnumber'
+        end
+
+        def parse_variable_kind attributes
+          HasAttributes.annotation_value attributes, 'conjur/kind'
+        end
+
+        def parse_variable_mime_type attributes
+          HasAttributes.annotation_value attributes, 'conjur/mime_type'
+        end
+
         def parse_members credentials, result
           result['members'].collect do |json|
             RoleGrant.parse_from_json(json, credentials)
           end
+        end
+
+        private
+
+        def resource_annotations resource
+          resource.attributes['annotations'] || {}
         end
       end
     end

--- a/lib/conjur/group.rb
+++ b/lib/conjur/group.rb
@@ -29,7 +29,13 @@ module Conjur
     # @return [Fixnum] the gidnumber
     # @raise [RestClient::Forbidden] if you don't have permission to `show` the group.
     def gidnumber
-      annotation_value 'conjur/gidnumber'
+      parser_for(:group_gidnumber, group_attributes)
+    end
+
+    private
+
+    def group_attributes
+      @group_attributes ||= url_for(:group_attributes, credentials, self, id)
     end
   end
 end

--- a/lib/conjur/has_attributes.rb
+++ b/lib/conjur/has_attributes.rb
@@ -23,6 +23,14 @@ module Conjur
   # methods on specific asset classes (for example, {Conjur::Resource#owner}), the are available as
   # a `Hash` on all types supporting attributes.
   module HasAttributes
+    class << self
+
+      # @api private
+      def annotation_value annotations, name
+        (annotations.find{|a| a['name'] == name} || {})['value']
+      end
+    end
+
     def as_json options={}
       result = super(options)
       if @attributes
@@ -67,7 +75,7 @@ module Conjur
     protected
 
     def annotation_value name
-      (attributes['annotations'].find{|a| a['name'] == name} || {})['value']
+      HasAttributes.annotation_value attributes['annotations'], name
     end
 
     # @api private

--- a/lib/conjur/user.rb
+++ b/lib/conjur/user.rb
@@ -28,7 +28,13 @@ module Conjur
     # @return [Fixnum] the uidnumber
     # @raise [RestClient::Forbidden] if you don't have permission to `show` the user.
     def uidnumber
-      annotation_value 'conjur/uidnumber'
+      parser_for(:user_uidnumber, user_attributes)
+    end
+
+    private
+
+    def user_attributes
+      @user_attributes ||= url_for(:user_attributes, credentials, self, id)
     end
   end
 end

--- a/lib/conjur/variable.rb
+++ b/lib/conjur/variable.rb
@@ -95,7 +95,7 @@ module Conjur
     # @note this is **not** the same as the `kind` part of a qualified Conjur id.
     # @return [String] a string representing the kind of secret.
     def kind
-      annotation_value 'conjur/kind' || "secret"
+      parser_for(:variable_kind, variable_attributes) || "secret"
     end
 
     # The MIME Type of the variable's value.
@@ -109,7 +109,7 @@ module Conjur
     #
     # @return [String] a MIME type, such as `'text/plain'` or `'application/octet-stream'`.
     def mime_type
-      annotation_value 'conjur/mime_type' || "text/plain"
+      parser_for(:variable_mime_type, variable_attributes) || "text/plain"
     end
 
     # Add a new value to the variable.
@@ -198,5 +198,11 @@ module Conjur
       options['version'] = version if version
       url_for(:secrets_value, credentials, id, options).get.body
     end
-  end
+
+    private
+
+    def variable_attributes
+      @variable_attributes ||= url_for(:variable_attributes, credentials, self, id)
+    end
+  end  
 end


### PR DESCRIPTION
In v4, objects such as Variable, User and Group have their own database table, and some fields (kind, mime_type, uidnumber, gidnumber) are stored on these tables, and can only be accessed through a URL route like `GET /<pluralized-object-kind>/<object-identifier>`

In v5, all this extended data is stored on annotations. 

This pull request add special JSON fetching and parsing logic to properly handle these attributes which differ between v4 and v5.

**Note** The CHANGELOG and VERSION are not updated yet, because v5.1.0 has not yet been released to Rubygems.

Build results : https://jenkins.conjur.net/job/cyberark--conjur-api-ruby/job/v4_field_compatibility/
