### PR TITLE
authenticate_local accepts service_id and authn_type parameters

### DIFF
--- a/lib/conjur/api/authn.rb
+++ b/lib/conjur/api/authn.rb
@@ -71,7 +71,7 @@ module Conjur
       # @param [String] username The username or host id for which we want a token
       # @param [String] account The organization account.
       # @return [String] A JSON formatted authentication token.
-      def authenticate_local username, account: Conjur.configuration.account, expiration: nil, cidr: nil
+      def authenticate_local username, account: Conjur.configuration.account, expiration: nil, cidr: nil, service_id: nil, authn_type: nil
         account ||= Conjur.configuration.account
         if Conjur.log
           Conjur.log << "Authenticating #{username} to account #{account} using authn_local\n"
@@ -79,7 +79,7 @@ module Conjur
 
         require 'json'
         require 'socket'
-        message = url_for(:authn_authenticate_local, username, account, expiration, cidr)
+        message = url_for(:authn_authenticate_local, username, account, expiration, cidr, service_id, authn_type)
         JSON.parse(UNIXSocket.open(Conjur.configuration.authn_local_socket) {|s| s.puts message; s.gets })        
       end
 

--- a/lib/conjur/api/router/v5.rb
+++ b/lib/conjur/api/router/v5.rb
@@ -16,10 +16,13 @@ module Conjur
         end
 
         # For v5, the authn-local message is a JSON string with account, sub, and optional fields.
-        def authn_authenticate_local username, account, expiration, cidr, &block
+        # Optional fields include the service_id and authn_type for a custom authenticator.
+        def authn_authenticate_local username, account, expiration, cidr, service_id, authn_type, &block
           { account: account, sub: username }.tap do |params|
             params[:exp] = expiration if expiration
             params[:cidr] = cidr if cidr
+            params[:service_id] = service_id if service_id
+            params[:authn_type] = authn_type if authn_type
           end.to_json
         end
 


### PR DESCRIPTION
This PR updates `authenticate_local` to accept the new parameters `service_id` and `authn_type` to support custom authenticators.

Note: the changes made below do change the order of arguments in the v5 router for `authn_authenticate_local`, but a review of our `cyberark` and `conjurinc` GH projects indicates that this is not in use anywhere yet.