### PR TITLE
Update API client to use updated Role members endpoint for search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Latest
 
+# Unreleased
+
+* Adds support for the Role endpoint for searching and paging Role Members
+
 # v5.1.0
 
 * Introduces backwards compatibility with Conjur 4.x for most API methods.

--- a/features/members.feature
+++ b/features/members.feature
@@ -21,13 +21,13 @@ Feature: Display role members and memberships.
     """
     [
       {
-        "admin_option": true,
-        "member": "cucumber:user:admin",
+        "admin_option": false,
+        "member": "cucumber:group:developers",
         "role": "cucumber:group:everyone"
       },
       {
-        "admin_option": false,
-        "member": "cucumber:group:developers",
+        "admin_option": true,
+        "member": "cucumber:user:admin",
         "role": "cucumber:group:everyone"
       }
     ]

--- a/lib/conjur/api/router/v5.rb
+++ b/lib/conjur/api/router/v5.rb
@@ -134,7 +134,7 @@ module Conjur
         end
 
         def parse_members credentials, result
-          result['members'].collect do |json|
+          result.map do |json|
             RoleGrant.parse_from_json(json, credentials)
           end
         end


### PR DESCRIPTION
For CONJ-5074

#### What does this PR do?

This PR updates the Conjur Ruby API to use the `?members` endpoint in Conjur Role API to return the members and make them searchable and pageable.

#### Background

In version 5, before the `?members` route was added, these requests were being handled by the role endpoint, which contains a `members` property. With this endpoint, the `parse_members` method needs to look at the JSON root, rather than the prior property path.

#### Link to build in Jenkins 
https://jenkins.conjur.net/job/cyberark--conjur-api-ruby/job/search_role_members/

#### Has the version and Changelog been updated?
Yes

#### What's left to do:
- [x] Merge corresponding `cyberark/conjur` PR
- [x] Update version and changelog
- [x] Update tests

