### PR TITLE
URL parameters with spaces are properly escaped in the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Adds support for the Role endpoint for searching and paging Role Members
 
+* Adds additional escaping to URL parameters on requests to handle special characters (e.g. spaces)
+
 # v5.1.0
 
 * Introduces backwards compatibility with Conjur 4.x for most API methods.

--- a/lib/conjur/api/router/v5.rb
+++ b/lib/conjur/api/router/v5.rb
@@ -82,7 +82,7 @@ module Conjur
           options = {}
           options[:check] = true
           options[:privilege] = privilege
-          options[:role] = cast_to_id(role) if role
+          options[:role] = path_escape(cast_to_id(role)) if role
           resources_resource(credentials, id)[options_querystring options].get
         end
 

--- a/lib/conjur/id.rb
+++ b/lib/conjur/id.rb
@@ -18,16 +18,19 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
+require 'conjur/escape'
 
 module Conjur
   # Encapsulates a Conjur id, which consists of account, kind, and identifier.
   class Id
+    include Conjur::Escape
+
     attr_reader :id
-    
+
     def initialize id
       @id = id
     end
-    
+
     # The organization account, obtained from the first component of the id.
     def account; id.split(':', 3)[0]; end
     # The object kind, obtained from the second component of the id.
@@ -52,7 +55,9 @@ module Conjur
 
     # Splits the id into 3 components, and then joins them with a forward-slash `/`.
     def to_url_path
-      id.split(':', 3).join('/')
+      id.split(':', 3)
+        .map(&method(:path_escape))
+        .join('/')
     end
     
     # @return [String] the id string

--- a/spec/uri_escape_spec.rb
+++ b/spec/uri_escape_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+require 'conjur/id'
+
+describe 'url escaping' do
+  it 'Id to path is escaped' do
+    id = Conjur::Id.new('cucumber:variable:foo bar')
+    expect(id.to_url_path).to eq('cucumber/variable/foo%20bar')
+  end
+end


### PR DESCRIPTION
#### What does this PR do?

This PR adds escaping to the resource name for two places in the API that cause the V5 UI to break.

#### What ticket does this PR close?
https://github.com/conjurinc/conjur-ui/issues/171

#### Where should the reviewer start?

I would appreciate any feedback on if there is a better way to use the `escape.rb` methods in `id.rb`.

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur-api-ruby/job/spaces_in_params/

#### Has the version and Changelog been updated?
Yes

#### Reviewers
#### Remaining Tasks:
- [x] Add tests for the failure case
- [x] Update changelog