### PR TITLE
Utils: Do not force pull in test.sh

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -20,7 +20,13 @@ function main() {
 function startConjur() {
   echo 'Starting Conjur environment'
   echo '-----'
-  docker-compose pull
+
+  # We want to pull to make sure we're testing against the newest release;
+  # failing to ensure that has caused many mysterious failures in CI.
+  # However, unconditionally pulling prevents working offline even
+  # with a warm cache. So try to pull, but ignore failures.
+  docker-compose pull --ignore-pull-failures
+
   docker-compose build
   docker-compose up -d pg conjur_4 conjur_5
 }


### PR DESCRIPTION
test.sh used to do `docker-compose pull` which unconditionally pulls
fresh images. Usually it's a waste of bandwidth and time:
`docker-compose build` already pulls any missing images, whereas
updating on every run means cache is busted and many images potentially
need to be rebuilt. It also prevents offline usage. If anything relies
on a recent image it should be explicitly pulled in.