### PR TITLE
Make resource ID escaping more consistent and add additional tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Latest
 
+* Updates URI path parameter escaping to consistently encode resource ids
+
 # v5.3.0
 
 * Add `Conjur::API.ldap_sync_policy` for fetching the LDAP sync policy.

--- a/lib/conjur/api/router/v5.rb
+++ b/lib/conjur/api/router/v5.rb
@@ -43,7 +43,7 @@ module Conjur
         end
 
         def authn_rotate_api_key credentials, account, id
-          RestClient::Resource.new(Conjur.configuration.core_url, credentials)['authn'][path_escape account]["api_key?role=#{id}"]
+          RestClient::Resource.new(Conjur.configuration.core_url, credentials)['authn'][fully_escape account]["api_key?role=#{id}"]
         end
 
         def authn_rotate_own_api_key account, username, password
@@ -66,18 +66,18 @@ module Conjur
         end
 
         def policies_load_policy credentials, account, id
-          RestClient::Resource.new(Conjur.configuration.core_url, credentials)['policies'][path_escape account]['policy'][path_escape id]
+          RestClient::Resource.new(Conjur.configuration.core_url, credentials)['policies'][fully_escape account]['policy'][fully_escape id]
         end
 
         def public_keys_for_user account, username
-          RestClient::Resource.new(Conjur.configuration.core_url)['public_keys'][fully_escape account]['user'][path_escape username]
+          RestClient::Resource.new(Conjur.configuration.core_url)['public_keys'][fully_escape account]['user'][fully_escape username]
         end
 
         def resources credentials, account, kind, options
           credentials ||= {}
 
-          path = "/resources/#{path_escape account}" 
-          path += "/#{path_escape kind}" if kind
+          path = "/resources/#{fully_escape account}"
+          path += "/#{fully_escape kind}" if kind
 
           RestClient::Resource.new(Conjur.configuration.core_url, credentials)[path][options_querystring options]
         end
@@ -97,7 +97,7 @@ module Conjur
           options = {}
           options[:check] = true
           options[:privilege] = privilege
-          options[:role] = path_escape(Id.new(role)) if role
+          options[:role] = query_escape(Id.new(role)) if role
           resources_resource(credentials, id)[options_querystring options].get
         end
 

--- a/lib/conjur/id.rb
+++ b/lib/conjur/id.rb
@@ -52,7 +52,7 @@ module Conjur
     # Splits the id into 3 components, and then joins them with a forward-slash `/`.
     def to_url_path
       id.split(':', 3)
-        .map(&method(:path_escape))
+        .map(&method(:fully_escape))
         .join('/')
     end
     

--- a/spec/uri_escape_spec.rb
+++ b/spec/uri_escape_spec.rb
@@ -1,9 +1,21 @@
 require 'spec_helper'
 require 'conjur/id'
+require 'conjur/api/router/v5'
 
 describe 'url escaping' do
   it 'Id to path is escaped' do
-    id = Conjur::Id.new('cucumber:variable:foo bar')
-    expect(id.to_url_path).to eq('cucumber/variable/foo%20bar')
+    id = Conjur::Id.new('cucumber:variable:one two/three')
+    expect(id.to_url_path).to eq('cucumber/variable/one%20two%2Fthree')
+  end
+
+  it 'Resources path is escaped' do
+    request = Conjur::API::Router::V5.resources(nil, 'cucumber/two', 'extended variable', {})
+    expect(request.url).to eq('http://localhost:5000/resources/cucumber%2Ftwo/extended%20variable/')
+  end
+
+  it 'Resource path is escaped' do
+    resource = Conjur::Id.new('cucumber:variable:one two/three')
+    request = Conjur::API::Router::V5.resources_resource(nil, resource)
+    expect(request.url).to eq('http://localhost:5000/resources/cucumber/variable/one%20two%2Fthree')
   end
 end


### PR DESCRIPTION
This PR adds additional tests for URL escaping to standardize on how path parameters should be escaped. Presently `fully_escape` and `path_escape` are used without a clear reason for selecting one versus the other.

I've updated many of the router methods to use `fully_escape` more consistently, rather than use path_escape, to account for the possibility of forward slashes in resource IDs.

This is related to https://github.com/conjurinc/conjur-ui/issues/210

#### Jenkins Build
https://jenkins.conjur.net/job/cyberark--conjur-api-ruby/job/uri_escaping/