### PR TITLE
Provide improved inspect method

### DIFF
--- a/lib/conjur/base_object.rb
+++ b/lib/conjur/base_object.rb
@@ -41,5 +41,10 @@ module Conjur
     def username
       credentials[:username] or raise "No username found in credentials"
     end
+
+    def inspect
+      "<#{self.class.name} id='#{id.to_s}'>"
+    end
+
   end
 end

--- a/spec/base_object_spec.rb
+++ b/spec/base_object_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Conjur::BaseObject do
+
+  it "returns custom string for #inspect" do
+    id_str = 'foo:bar:baz'
+    base_obj = Conjur::BaseObject.new(Conjur::Id.new(id_str), { username: 'foo' })
+    expect(base_obj.inspect).to include("id='#{id_str}'")
+    expect(base_obj.inspect).to include(Conjur::BaseObject.name)
+  end
+
+end


### PR DESCRIPTION
Added a custom inspect method to the `BaseObject` class that simply prints the class name and the id, instead of the less readability version from `Object`.  As this is a superclass, all subclasses will now inherit this version of the inspect method.

Example:
```ruby
[4] pry(main)> a.inspect
=> "<Conjur::User id='admin:user:admin'>"
```