### PR TITLE
Publish coverage to Code Climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,8 +1,10 @@
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-0-58
+    channel: rubocop-0-76
   reek:
     enabled: true
   brakeman:
     enabled: false
+  shellcheck:
+    enabled: true

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Gemfile.lock
 InstalledFiles
 _yardoc
 coverage
+coverage_v4
 doc/
 lib/bundler/man
 pkg

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,12 @@ pipeline {
   }
 
   stages {
+
     stage('Test') {
       steps {
+        script {
+          ccCoverage.setGitEnvVars();
+        }
         milestone(1)
         sh './test.sh'
       }
@@ -25,8 +29,6 @@ pipeline {
           junit 'features/reports/*.xml'
           junit 'features_v4/reports/*.xml'
           cobertura autoUpdateHealth: true, autoUpdateStability: true, coberturaReportFile: 'coverage/coverage.xml', conditionalCoverageTargets: '100, 0, 0', failUnhealthy: true, failUnstable: false, lineCoverageTargets: '99, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '100, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
-          // TODO: Uncomment this once CC for this repo is enabled
-          // ccCoverage("cobertura")        
         }
       }
     }

--- a/ci/codeclimate.dockerfile
+++ b/ci/codeclimate.dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.11
+RUN wget https://codeclimate.com/downloads/test-reporter/test-reporter-0.6.3-linux-amd64 -O /opt/cc-test-reporter
+RUN chmod +x /opt/cc-test-reporter
+RUN apk update && apk upgrade && apk add --no-cache git
+
+ENTRYPOINT ["/opt/cc-test-reporter"]

--- a/test.sh
+++ b/test.sh
@@ -8,6 +8,18 @@ function finish {
 
 trap finish EXIT
 
+function publishToCodeClimate() {
+  docker build -f ci/codeclimate.dockerfile -t cyberark/code-climate:latest .
+  docker run \
+    --rm \
+    --volume "$PWD:/src/conjur-api" \
+    -w "/src/conjur-api" \
+    cyberark/code-climate:latest \
+      after-build \
+        -r "$(<TRID)" \
+        -t "simplecov"
+}
+
 function main() {
   # Generate reports folders locally
   mkdir -p spec/reports features/reports features_v4/reports
@@ -15,6 +27,7 @@ function main() {
   startConjur
   runTests_5
   runTests_4
+  publishToCodeClimate
 }
 
 function startConjur() {


### PR DESCRIPTION
This commit adds a Docker container to handle publishing coverage reports to Code Climate. A docker container based install was chosen to allow a developer to run the CC publish step locally.