### PR TITLE
Remove parse-changelog.sh from gem executables

### DIFF
--- a/.rubocop_settings.yml
+++ b/.rubocop_settings.yml
@@ -83,3 +83,4 @@ Metrics/BlockLength:
     - 'Rakefile'
     - '**/*.rake'
     - 'spec/**/*.rb'
+    - 'conjur-api.gemspec'

--- a/conjur-api.gemspec
+++ b/conjur-api.gemspec
@@ -18,6 +18,9 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9'
 
+  # Filter out development only executables
+  gem.executables -= %w{parse-changelog.sh}
+
   gem.add_dependency 'rest-client'
   gem.add_dependency 'activesupport'
 


### PR DESCRIPTION
This PR removes `parse-changelog.sh` from the Gemspec executables.

Connected to cyberark/conjur-cli#261 

`parse-changelog.sh` is a development dependency of the API, and when other Gems also include this script, it causes an error when installed together.

For example, installing both `conjur-api` and `conjur-cli` leads to:
```
$ gem install ./conjur-cli-6.2.1.gem
conjur-cli's executable "parse-changelog.sh" conflicts with conjur-api
```