### PR TITLE
Publish to RubyGems on tagged version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,30 +120,20 @@ $ docker-compose down
 
 ## Releasing
 
-Releasing a new version of this Gem involves a two step process:
-1. Tag and Release (using `bin/release`)
-2. Approving the push to RubyGems in Jenkins
+Releasing a new version of this Gem:
 
-### Step 1: Tag and Release
+1. Update the version
+1. Run the release script
 
-First, update the following files:
+### Update The Version
 
 - The version file (`lib/conjur-api/version.rb`) has been updated with an appropriate Semantic version number.
 - The `CHANGELOG.md` file has been updated to reflect the release version and appropriate release notes.
 
 Next, save -- but do not commit -- the changes above.
 
-Finally, when you're ready to release, run the following:
+### Run The Release Script
 
 ```sh
-$ bin/release
+./bin/release
 ```
-
-### Step 2: Approve the push to RubyGems in Jenkins
-
-- Navigate to Jenkins: https://jenkins.conjur.net/job/cyberark--conjur-api-ruby/job/master/.
-- Once the pipeline reaches the `Publish to RubyGems?` stage, click the blue box, and then click `Logs`.
-- Open the confirmation step (`Wait for interactive input -- Publish to RubyGems?`), and click `Proceed`. Nothing appears to happen, but the "Publish" stage will be run.
-- Finally, verify that the new library is present in RubyGems: https://rubygems.org/gems/conjur-api
-
-The release is now complete.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,31 +41,13 @@ pipeline {
     }
 
     // Only publish to RubyGems if branch is 'master'
-    // AND someone confirms this stage within 5 minutes
+    // AND the tag begins with 'v' ex) v5.3.2
     stage('Publish to RubyGems?') {
       agent { label 'releaser-v2' }
 
       when {
         allOf {
-          branch 'master'
-          expression {
-            boolean publish = false
-
-            if (env.PUBLISH_GEM == "true") {
-                return true
-            }
-
-            try {
-              timeout(time: 5, unit: 'MINUTES') {
-                input(message: 'Publish to RubyGems?')
-                publish = true
-              }
-            } catch (final ignore) {
-              publish = false
-            }
-
-            return publish
-          }
+          branch 'master'; tag "v*"
         }
       }
       steps {


### PR DESCRIPTION
### What does this PR do?

Changes the publish to RubyGems process to publish on push to master with a tagged(v*) release. Ex) `v5.3.2`

More notes in the issue.

### What ticket does this PR close?
Connected to https://github.com/cyberark/conjur-api-ruby/issues/173

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ x ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ x ] The changes in this PR do not require tests

#### Documentation
- [ x ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation