### PR TITLE
Add explicit failure for `resource(<own_id>).rotate_api_key`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- When rotating the currently logged in user's/host's API key, we now explictily
+  prevent use of `resource(<own_id>).rotate_api_key` for that action as the
+  `Conjur::API.rotate_api_key` should be used instead for that.
+  [cyberark/conjur-api-ruby#181](https://github.com/cyberark/conjur-api-ruby/issues/181)
+
 ## [5.3.3] - 2020-08-18
 ### Changed
 - Release process is updated to ensure that the published Ruby Gem matches a tag in this repository,
   so that consumers of this gem can always reference the correct source code included in any given version.
-  [cyberark/conjur-api-ruby](https://github.com/cyberark/conjur-api-ruby/issues/173)
+  [cyberark/conjur-api-ruby#173](https://github.com/cyberark/conjur-api-ruby/issues/173)
 
 ## 5.3.2 - 2018-09-24
 ### Added

--- a/features/host.feature
+++ b/features/host.feature
@@ -1,20 +1,50 @@
-Feature: Display Host object fields.
+Feature: Host object
 
-  Background:
+  Scenario: API key of a newly created host is available and valid
     Given a new host
-
-  Scenario: API key of a newly created host is available and valid.
-    Then I run the code:
+    Then I can run the code:
     """
     expect(@host.exists?).to be(true)
     expect(@host.api_key).to be
     Conjur::API.new_from_key(@host.login, @host.api_key).token
     """
 
-  Scenario: API key of a a host can be rotated.
-    Then I run the code:
+  # Rotation of own API key should be done via `Conjur::API.rotate_api_key()`
+  Scenario: Host's own API key cannot be rotated with an API key
+    Given a new host
+    Then this code should fail with "You cannot rotate your own API key via this method"
     """
     host = Conjur::API.new_from_key(@host.login, @host.api_key).resource(@host.id)
-    api_key = host.rotate_api_key
-    Conjur::API.new_from_key(@host.login, api_key).token
+    host.rotate_api_key
+    """
+
+  # Rotation of own API key should be done via `Conjur::API.rotate_api_key()`
+  Scenario: Host's own API key cannot be rotated with a token
+    Given a new host
+    Then this code should fail with "You cannot rotate your own API key via this method"
+    """
+    token = Conjur::API.new_from_key(@host.login, @host.api_key).token
+
+    host = Conjur::API.new_from_token(token).resource(@host.id)
+    host.rotate_api_key
+    """
+
+  Scenario: Delegated host's API key can be rotated with an API key
+    Given a new delegated host
+    Then I can run the code:
+    """
+    delegated_host_resource = Conjur::API.new_from_key(@host_owner.login, @host_owner_api_key).resource(@host.id)
+    api_key = delegated_host_resource.rotate_api_key
+    Conjur::API.new_from_key(delegated_host_resource.login, api_key).token
+    """
+
+  Scenario: Delegated host's API key can be rotated with a token
+    Given a new delegated host
+    Then I can run the code:
+    """
+    token = Conjur::API.new_from_key(@host_owner.login, @host_owner_api_key).token
+
+    delegated_host_resource = Conjur::API.new_from_token(token).resource(@host.id)
+    api_key = delegated_host_resource.rotate_api_key
+    Conjur::API.new_from_key(delegated_host_resource.login, api_key).token
     """

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -1,7 +1,18 @@
-When(/^I(?: can)? run the code:$/) do |code|
+Then(/^I(?: can)? run the code:$/) do |code|
   @result = eval(code).tap do |result|
-    if ENV['DEBUG']
-      puts result
+    puts result if ENV['DEBUG']
+  end
+end
+
+Then(/^this code should fail with "([^"]*)"$/) do |error_msg, code|
+  begin
+    @result = eval(code)
+  rescue Exception => exc
+    if not exc.message =~ %r{#{error_msg}}
+      fail "'#{error_msg}' was not found in '#{exc.message}'"
     end
+  else
+    puts @result if ENV['DEBUG']
+    fail "The provided block did not raise an error"
   end
 end

--- a/features/user.feature
+++ b/features/user.feature
@@ -1,17 +1,58 @@
-Feature: Display User object fields.
+Feature: User object
 
   Background:
-    Given a new user
 
-  Scenario: User has a uidnumber.
-    Then I run the code:
+  Scenario: User has a uidnumber
+    Given a new user
+    Then I can run the code:
     """
     @user.uidnumber
     """
     Then the result should be "1000"
 
-  Scenario: Logged-in user is the current_role.
-    Then I run the code:
+  Scenario: Logged-in user is the current_role
+    Given a new user
+    Then I can run the code:
     """
     expect($conjur.current_role(Conjur.configuration.account).id.to_s).to eq("cucumber:user:admin")
+    """
+
+  # Rotation of own API key should be done via `Conjur::API.rotate_api_key()`
+  Scenario: User's own API key cannot be rotated with an API key
+    Given a new user
+    Then this code should fail with "You cannot rotate your own API key via this method"
+    """
+    user = Conjur::API.new_from_key(@user.login, @user_api_key).resource(@user.id)
+    user.rotate_api_key
+    """
+
+  # Rotation of own API key should be done via `Conjur::API.rotate_api_key()`
+  Scenario: User's own API key cannot be rotated with a token
+    Given a new user
+    Then this code should fail with "You cannot rotate your own API key via this method"
+    """
+    token = Conjur::API.new_from_key(@user.login, @user_api_key).token
+
+    user = Conjur::API.new_from_token(token).resource(@user.id)
+    user.rotate_api_key
+    """
+
+  Scenario: Delegated user's API key can be rotated with an API key
+    Given a new delegated user
+    Then I can run the code:
+    """
+    delegated_user_resource = Conjur::API.new_from_key(@user_owner.login, @user_owner_api_key).resource(@user.id)
+    api_key = delegated_user_resource.rotate_api_key
+    Conjur::API.new_from_key(delegated_user_resource.login, api_key).token
+    """
+
+  Scenario: Delegated user's API key can be rotated with a token
+    Given a new delegated user
+    Then I can run the code:
+    """
+    token = Conjur::API.new_from_key(@user_owner.login, @user_owner_api_key).token
+
+    delegated_user_resource = Conjur::API.new_from_token(token).resource(@user.id)
+    api_key = delegated_user_resource.rotate_api_key
+    Conjur::API.new_from_key(delegated_user_resource.login, api_key).token
     """

--- a/lib/conjur/acts_as_user.rb
+++ b/lib/conjur/acts_as_user.rb
@@ -52,12 +52,16 @@ module Conjur
     # @note You will not be able to access the API key returned by this method later, so you should
     #   probably hang onto it it.
     #
-    # @note You cannot rotate your own API key with this method. To do so, use `Conjur::API.rotate_api_key`
+    # @note You cannot rotate your own API key with this method. To do so, use `Conjur::API.rotate_api_key`.
     #
     # @note This feature requires a Conjur appliance running version 4.6 or higher.
     #
     # @return [String] the new API key for this user.
     def rotate_api_key
+      if login == username
+        raise 'You cannot rotate your own API key via this method. To do so, use `Conjur::API.rotate_api_key`'
+      end
+
       url_for(:authn_rotate_api_key, credentials, account, id).put("").body
     end
   end

--- a/lib/conjur/api/resources.rb
+++ b/lib/conjur/api/resources.rb
@@ -20,7 +20,7 @@ module Conjur
   class API
     include QueryString
     include BuildObject
-    
+
     #@!group Resources
 
     # Find a resource by its id.
@@ -84,7 +84,7 @@ module Conjur
     def resources options = {}
       options = { host: Conjur.configuration.core_url, credentials: credentials }.merge options
       options[:account] ||= Conjur.configuration.account
-      
+
       host, credentials, account, kind = options.values_at(*[:host, :credentials, :account, :kind])
       fail ArgumentError, "host and account are required" unless [host, account].all?
       %w(host credentials account kind).each do |name|

--- a/lib/conjur/api/router/v5.rb
+++ b/lib/conjur/api/router/v5.rb
@@ -169,7 +169,7 @@ module Conjur
         def ldap_sync_policy(credentials, config_name)
           RestClient::Resource.new(Conjur.configuration.core_url, credentials)['ldap-sync']["policy?config_name=#{fully_escape(config_name)}"]
         end
-        
+
         private
 
         def resource_annotations resource

--- a/lib/conjur/base_object.rb
+++ b/lib/conjur/base_object.rb
@@ -20,9 +20,9 @@ module Conjur
     include LogSource
     include BuildObject
     include Routing
-    
+
     attr_reader :id, :credentials
-    
+
     def initialize id, credentials
       @id = Id.new id
       @credentials = credentials
@@ -34,10 +34,18 @@ module Conjur
       }
     end
 
-    def account; id.account; end
-    def kind; id.kind; end
-    def identifier; id.identifier; end
-    
+    def account
+      id.account
+    end
+
+    def kind
+      id.kind
+    end
+
+    def identifier
+      id.identifier
+    end
+
     def username
       credentials[:username] or raise "No username found in credentials"
     end
@@ -45,6 +53,5 @@ module Conjur
     def inspect
       "<#{self.class.name} id='#{id.to_s}'>"
     end
-
   end
 end

--- a/spec/base_object_spec.rb
+++ b/spec/base_object_spec.rb
@@ -10,5 +10,4 @@ describe Conjur::BaseObject do
     expect(base_obj.inspect).to include("id='#{id_str}'")
     expect(base_obj.inspect).to include(Conjur::BaseObject.name)
   end
-
 end


### PR DESCRIPTION
This change modifies the API to reject attempts at using the
`resource(<own_id>).rotate_api_key` for changing your own API key
as `Conjur::API.rotate_api_key` should be used instead for that.
Additional test cases are now included to cover all logic paths and
proper extraction of the username from a JWT to enable this
functionality.

### What ticket does this PR close?
Connected to #181 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation