### PR TITLE
Bump version to v5.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [5.3.4] - 2020-10-29
+
 ### Changed
 - When rotating the currently logged in user's/host's API key, we now explictily
   prevent use of `resource(<own_id>).rotate_api_key` for that action as the
-  `Conjur::API.rotate_api_key` should be used instead for that.
+  `Conjur::API.rotate_api_key` should be used instead for that. This change is a
+  downstream enforcement of the stricter key rotation requirements on the server
+  covered by [this](https://github.com/cyberark/conjur/security/advisories/GHSA-qhjf-g9gm-64jq)
+  security bulletin.
   [cyberark/conjur-api-ruby#181](https://github.com/cyberark/conjur-api-ruby/issues/181)
 
 ## [5.3.3] - 2020-08-18
@@ -327,7 +332,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.0.0] - 2013-13-12
 
-[Unreleased]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.3...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.4...HEAD
+[5.3.4]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.3...v5.3.4
 [5.3.3]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.1...v5.3.3
 [5.3.1]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.0...v5.3.1
 [5.3.0]: https://github.com/cyberark/conjur-api-ruby/compare/v5.1.0...v5.3.0

--- a/lib/conjur-api/version.rb
+++ b/lib/conjur-api/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2013-2017 Conjur Inc.
+# Copyright 2013-2020 Conjur Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -19,6 +19,6 @@
 
 module Conjur
   class API
-    VERSION = "5.3.3"
+    VERSION = "5.3.4"
   end
 end


### PR DESCRIPTION
This change prepares the API for a release of v5.3.4 with fixed to key
rotation logic.

### What ticket does this PR close?
Connected to #182

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation