### PR TITLE
Remove cobertura from the jenkinsfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in conjur-api.gemspec
 gemspec
-
-group :test do
-  gem 'simplecov-cobertura', require: false
-end

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,9 +73,6 @@ pipeline {
           junit 'spec/reports/*.xml'
           junit 'features/reports/*.xml'
           junit 'features_v4/reports/*.xml'
-          cobertura autoUpdateHealth: true, autoUpdateStability: true, coberturaReportFile: 'coverage/coverage.xml',
-            conditionalCoverageTargets: '100, 0, 0', failUnhealthy: true, failUnstable: false, lineCoverageTargets: '99, 0, 0',
-            maxNumberOfBuilds: 0, methodCoverageTargets: '100, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
         }
       }
     }

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,7 +1,5 @@
 require 'simplecov'
-require 'simplecov-cobertura'
 
-SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 SimpleCov.start do
   command_name "#{ENV['RUBY_VERSION']}"
 end

--- a/features_v4/support/env.rb
+++ b/features_v4/support/env.rb
@@ -1,7 +1,5 @@
 require 'simplecov'
-require 'simplecov-cobertura'
 
-SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 SimpleCov.start
 
 require 'json_spec/cucumber'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,5 @@
 require 'simplecov'
-require 'simplecov-cobertura'
 
-SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 SimpleCov.start do
   command_name "#{ENV['RUBY_VERSION']}"
 end


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_
Cobertura was deemed unnecessary by the infrastructure team, and though originally left in, it changed its line coverage rating on files that weren't altered. It was decided to remove the line publishing the report, and instead use only ccCoverage. 
- _How should the reviewer approach this PR, especially if manual tests are required?_
Make sure the Jenkinsfile is in align with the teams' standards. 
- _Are there relevant screenshots you can add to the PR description?_
No
### What ticket does this PR close?
Connected to #174
### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation