### PR TITLE
Updating naming for Conjur editions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Use the configuration setting `Conjur.configuration.version` to select your serv
 
 If you are using Conjur server version `4.x`, you can also choose to use the `conjur-api` version `4.x`. In this case, the `Configuration.version` setting is not required (actually, it doesn't exist).
 
-## Using conjur-api-ruby with Conjur OSS 
+## Using conjur-api-ruby with Conjur Open Source 
 
-Are you using this project with [Conjur OSS](https://github.com/cyberark/conjur)? Then we 
+Are you using this project with [Conjur Open Source](https://github.com/cyberark/conjur)? Then we 
 **strongly** recommend choosing the version of this project to use from the latest [Conjur OSS 
 suite release](https://docs.conjur.org/Latest/en/Content/Overview/Conjur-OSS-Suite-Overview.html). 
 Conjur maintainers perform additional testing on the suite release versions to ensure 


### PR DESCRIPTION
Updating naming for Conjur editions

- converts `Conjur OSS` to `Conjur Open Source`
- converts `DAP`/`Dynamic Access Provider` to `Conjur Enterprise`
- maintains `Conjur OSS Suite` and `Conjur Open Source Suite`

This is part of an automated batch of PRs across many repos listed in [cyberark/community#92](https://github.com/cyberark/community/issues/92)
