### PR TITLE
Bump version to 5.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [5.3.6] - 2021-12-09
 ### Changed
-- Upgrade and set ruby-3.0.2 as default.
+- Support ruby-3.0.2 - functionality and rspec/cucumber.
   [cyberark/conjur-api-ruby#197](https://github.com/cyberark/conjur-api-ruby/pull/197)
 
 ## [5.3.5] - 2021-05-04
@@ -349,7 +351,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.0.0] - 2013-13-12
 
-[Unreleased]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.5...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.6...HEAD
+[5.3.6]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.5...v5.3.6
 [5.3.5]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.4...v5.3.5
 [5.3.4]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.3...v5.3.4
 [5.3.3]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.1...v5.3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [5.3.6] - 2021-12-09
 ### Changed
-- Support ruby-3.0.2 - functionality and rspec/cucumber.
+- Support ruby-3.0.2.
   [cyberark/conjur-api-ruby#197](https://github.com/cyberark/conjur-api-ruby/pull/197)
 
 ## [5.3.5] - 2021-05-04

--- a/lib/conjur-api/version.rb
+++ b/lib/conjur-api/version.rb
@@ -19,6 +19,6 @@
 
 module Conjur
   class API
-    VERSION = "5.3.5"
+    VERSION = "5.3.6"
   end
 end


### PR DESCRIPTION
### Desired Outcome

Bump conjur-api-ruby version to 5.3.6.

### Implemented Changes

Modified changelog and version.rb file.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-14614](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14614)

### Definition of Done

Version 5.3.6 is staged for tagging.

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
