### PR TITLE
Addressable gem dependency update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Change addressable gem dependency.
+  [cyberark/conjur-api-ruby#199](https://github.com/cyberark/conjur-api-ruby/pull/199)
+
 ## [5.3.6] - 2021-12-09
+
 ### Changed
 - Support ruby-3.0.2.
   [cyberark/conjur-api-ruby#197](https://github.com/cyberark/conjur-api-ruby/pull/197)

--- a/conjur-api.gemspec
+++ b/conjur-api.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'rest-client'
   gem.add_dependency 'activesupport', '>= 4.2'
-  gem.add_dependency 'addressable', '~> 2.8.0'
+  gem.add_dependency 'addressable', '~> 2.0'
 
   gem.add_development_dependency 'rake', '>= 12.3.3'
   gem.add_development_dependency 'rspec', '~> 3'


### PR DESCRIPTION
### Desired Outcome

Addressable dependency changed from (~> 2.8.0) to (~2.0) to allow compatability with other gems in conjur.

### Implemented Changes

Change dependency in conjur-api.gemspec

### Connected Issue/Story

CyberArk internal issue link: [ONYX-14705](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14705)

### Definition of Done

Same addressable version (2.8.0) is used within conjur-api-ruby.
Dependency changed to (~> 2.0).
Jenkins CI tests are green.

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
