### PR TITLE
ONYX-14702: Update to use automated release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 ### Changed
-- Nothing should go in this section, please add to the latest unreleased version, or
-  add a new version.
+- Nothing should go in this section, please add to the latest unreleased version
+  (and update the corresponding date), or add a new version.
 
 ## [5.3.7] - 2021-12-28
 
@@ -363,6 +363,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.0.0] - 2013-13-12
 
 [Unreleased]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.6...HEAD
+[5.3.7]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.6...v5.3.7
 [5.3.6]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.5...v5.3.6
 [5.3.5]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.4...v5.3.5
 [5.3.4]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.3...v5.3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
+### Changed
+- Nothing should go in this section, please add to the latest unreleased version, or
+  add a new version.
+
+## [5.3.7] - 2021-12-28
 
 ### Changed
 - Change addressable gem dependency.
   [cyberark/conjur-api-ruby#199](https://github.com/cyberark/conjur-api-ruby/pull/199)
+- Update to use automated release process
 
 ## [5.3.6] - 2021-12-09
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y vim curl
 
 WORKDIR /src/conjur-api
 
-COPY Gemfile conjur-api.gemspec ./
+COPY Gemfile conjur-api.gemspec VERSION ./
 COPY lib/conjur-api/version.rb ./lib/conjur-api/
 
 RUN bundle

--- a/conjur-api.gemspec
+++ b/conjur-api.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/cyberark/conjur-api-ruby/"
   gem.license       = "Apache-2.0"
 
-  gem.files         = `git ls-files`.split($\) + Dir['build_number']
+  gem.files         = `git ls-files`.split($\).append("VERSION") + Dir['build_number']
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "conjur-api"

--- a/lib/conjur-api/version.rb
+++ b/lib/conjur-api/version.rb
@@ -19,6 +19,6 @@
 
 module Conjur
   class API
-    VERSION = "5.3.6"
+    VERSION = File.read(File.expand_path('../../VERSION', __dir__))
   end
 end


### PR DESCRIPTION
### Desired Outcome

Update to use automated release process, providing continues delivery of releases appropriately marked as pre-release and provide a lightweight route for promoting a given pre-release to customer release.

### Implemented Changes

When a build is triggered by a dependency or from a merge to master, the project will be built, a prerelease version published to rubygems, and a github pre-release release created or updated based on the changelog.  Builds will indicate the type of build it is (BUILD, RELEASE, PROMOTE or SKIP) in the description and the associated versions used. The version used is determined on the latest version in the changelog, so if a version (say 1.2.3) has been promoted, and a merge occurs without a new version being added to the changelog, the build will fail on the main branch.  To promote a release to a customer release (remove the pre-release mark from the github release and publish a full version to rubygems), on the main branch select `PROMOTE` and enter the version to promote (e.g., `1.2.3-4`), findable in the build description or build log.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-14702](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14702)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] Internal documentation will be updated in a follow-up issue
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
