### PR TITLE
Update to use release-tools publish-rubygem

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,6 +154,7 @@ pipeline {
                 -e bom-assets/ \
                 -e release-assets/ '''
           sh './publish.sh'
+          sh 'cp conjur-api-*.gem release-assets/.'
         }
       }
     }

--- a/publish.sh
+++ b/publish.sh
@@ -1,7 +1,5 @@
-#!/bin/bash -e
-
-docker pull registry.tld/conjurinc/publish-rubygem
+#!/usr/bin/env bash
+set -e
 
 summon --yaml "RUBYGEMS_API_KEY: !var rubygems/api-key" \
-  docker run --rm --env-file @SUMMONENVFILE -v "$(pwd)":/opt/src \
-  registry.tld/conjurinc/publish-rubygem conjur-api
+  publish-rubygem conjur-api


### PR DESCRIPTION
This moves away from the publish-rubygem container to use the
release-tools provided publish-rubygem.  This allows the gem file
to be archived along with the release rather than just on rubygems.org

Release builds will fail until conjurinc/release-tools#17 has been merged.