### PR TITLE
Remove support for Ruby <2.7

### DIFF
--- a/.rubocop_settings.yml
+++ b/.rubocop_settings.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
 
 # These non-default settings best reflect our current code style.
 Style/MethodDefParentheses:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
-## [5.3.8] - 2022-01-31
+## [5.3.8] - 2022-04-26
+
+### Changed
+- Remove support for Ruby versions <2.7 which are [end of life](https://endoflife.date/ruby).
+  [cyberark/conjur-api-ruby#206](https://github.com/cyberark/conjur-api-ruby/pull/206)
 
 ## [5.3.7] - 2021-12-28
 
@@ -364,7 +368,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.0.0] - 2013-13-12
 
-[Unreleased]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.6...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.8...HEAD
+[5.3.8]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.7...v5.3.8
 [5.3.7]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.6...v5.3.7
 [5.3.6]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.5...v5.3.6
 [5.3.5]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.4...v5.3.5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,11 +123,8 @@ $ docker-compose down
 ### Update the version and changelog
 
 1. Create a new branch for the version bump.
-1. Based on the unreleased content, determine the new version number and update
-    the [version.rb](lib/conjur-api/version.rb) file.
 1. Commit these changes - `Bump version to x.y.z` is an acceptable commit message - and open a PR
-   for review. Your PR should include updates to `lib/conjur-api/version.rb`, and
-    `CHANGELOG.md`.
+   for review. Your PR should include updates to `CHANGELOG.md`.
 
 ### Add a git tag
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,40 +58,6 @@ pipeline {
       }
     }
 
-    stage('Test Ruby 2.5') {
-      environment {
-        RUBY_VERSION = '2.5'
-      }
-      steps {
-        sh './test.sh'
-      }
-
-      post {
-        always {
-          junit 'spec/reports/*.xml'
-          junit 'features/reports/*.xml'
-          junit 'features_v4/reports/*.xml'
-        }
-      }
-    }
-
-    stage('Test Ruby 2.6') {
-      environment {
-        RUBY_VERSION = '2.6'
-      }
-      steps {
-        sh './test.sh'
-      }
-
-      post {
-        always {
-          junit 'spec/reports/*.xml'
-          junit 'features/reports/*.xml'
-          junit 'features_v4/reports/*.xml'
-        }
-      }
-    }
-
     stage('Test Ruby 2.7') {
       environment {
         RUBY_VERSION = '2.7'

--- a/bin/parse-changelog.sh
+++ b/bin/parse-changelog.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"
 docker run --rm \
   -v "$PWD/..:/work" \
   -w "/work" \
-  ruby:2.5 bash -ec "
+  ruby:2.7 bash -ec "
     gem install -N parse_a_changelog
     parse ./CHANGELOG.md
   "

--- a/dev/Dockerfile.dev
+++ b/dev/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.7
 
 RUN apt-get update && apt-get install -y vim curl
 


### PR DESCRIPTION
### Desired Outcome

dev/Dockerfile.dev in conjur-api-ruby uses the ruby:2.5 base image. This image includes a number of known vulnerabilities. Update this to a later version (preferably one that matches our upgraded Ruby version everywhere else).

### Implemented Changes

- Remove support for Ruby versions below 2.7, which are [end of life](https://endoflife.date/ruby).

### Connected Issue/Story

CyberArk internal issue link: [ONYX-16435](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-16435)

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
