### PR TITLE
Allow raw response on OIDC authentication request

### DIFF
--- a/features/authn.feature
+++ b/features/authn.feature
@@ -3,7 +3,7 @@ Feature: Authenticate with Conjur
   Background:
     Given I setup a keycloak authenticator
 
-  Scenario: Authenticate with OIDC state and code
+  Scenario: Authenticate with OIDC code
     When I retrieve the provider details for OIDC authenticator "keycloak"
     And I retrieve auth info for the OIDC provider with username: "alice" and password: "alice"
     And I run the code:
@@ -12,3 +12,14 @@ Feature: Authenticate with Conjur
     Conjur::API.authenticator_authenticate("authn-oidc", "keycloak", options: @auth_body)
     """
     Then the JSON should have "payload"
+
+  Scenario: Authenticate with OIDC code requesting unparsed result
+    When I retrieve the provider details for OIDC authenticator "keycloak"
+    And I retrieve auth info for the OIDC provider with username: "alice" and password: "alice"
+    And I run the code:
+    """
+    $conjur.authenticator_enable "authn-oidc", "keycloak"
+    Conjur::API.authenticator_authenticate_get("authn-oidc", "keycloak", options: @auth_body)
+    """
+    Then the response body contains: "payload"
+    And the response includes headers

--- a/features/authn.feature
+++ b/features/authn.feature
@@ -4,7 +4,7 @@ Feature: Authenticate with Conjur
     Given I setup a keycloak authenticator
 
   Scenario: Authenticate with OIDC state and code
-    When I retrieve the login url for OIDC authenticator "keycloak"
+    When I retrieve the provider details for OIDC authenticator "keycloak"
     And I retrieve auth info for the OIDC provider with username: "alice" and password: "alice"
     And I run the code:
     """

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -17,9 +17,11 @@ Then(/^this code should fail with "([^"]*)"$/) do |error_msg, code|
   end
 end
 
-Given(/^I retrieve the login url for OIDC authenticator "([^"]+)"$/) do |service_id|
+Given(/^I retrieve the provider details for OIDC authenticator "([^"]+)"$/) do |service_id|
   provider = $conjur.authentication_providers("authn-oidc").select {|provider_details| provider_details["service_id"] == service_id}
   @login_url = provider[0]["redirect_uri"]
+  @nonce = provider[0]["nonce"]
+  @code_verifier = provider[0]["code_verifier"]
   puts @login_url
 end
 
@@ -47,6 +49,6 @@ Given(/^I retrieve auth info for the OIDC provider with username: "([^"]+)" and 
 
   if response.is_a?(Net::HTTPRedirection)
     response_details = URI.decode_www_form(URI(response['location']).query)
-    @auth_body = {state: response_details.assoc('state')[1], code: response_details.assoc('code')[1]}
+    @auth_body = {code: response_details.assoc('code')[1], nonce: @nonce, code_verifier: @code_verifier}
   end
 end

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -52,3 +52,11 @@ Given(/^I retrieve auth info for the OIDC provider with username: "([^"]+)" and 
     @auth_body = {code: response_details.assoc('code')[1], nonce: @nonce, code_verifier: @code_verifier}
   end
 end
+
+Then(/^the response body contains: "([^"]+)"$/) do |element|
+  expect(@result).to include(element)
+end
+
+Then(/^the response includes headers$/) do
+  expect(@result.headers).not_to be_empty
+end

--- a/lib/conjur/api/authn.rb
+++ b/lib/conjur/api/authn.rb
@@ -63,10 +63,22 @@ module Conjur
       # @param [Hash] params Additional params to send to authenticator
       # @return [String] A JSON formatted authentication token.
       def authenticator_authenticate authenticator, service_id, account: Conjur.configuration.account, options: {}
+        JSON.parse authenticator_authenticate_get authenticator, service_id, account: account, options: options
+      end
+
+      # Authenticates using a third party authenticator like authn-oidc via GET request.
+      # It will return an response object containing access/refresh token data.
+      #
+      # @param [String] authenticator
+      # @param [String] service_id
+      # @param [String] account The organization account.
+      # @param [Hash] params Additional params to send to authenticator
+      # @return [RestClient::Response] Response object
+      def authenticator_authenticate_get authenticator, service_id, account: Conjur.configuration.account, options: {}
         if Conjur.log
           Conjur.log << "Authenticating to account #{account} using #{authenticator}/#{service_id}\n"
         end
-        JSON.parse url_for(:authenticator_authenticate, account, service_id, authenticator, options).get
+        url_for(:authenticator_authenticate, account, service_id, authenticator, options).get
       end
 
       # Exchanges Conjur the API key (refresh token) for an access token.  The access token can

--- a/spec/api/host_factories_spec.rb
+++ b/spec/api/host_factories_spec.rb
@@ -13,7 +13,7 @@ describe "Conjur::API.host_factory_create_host", api: :dummy do
         resource = instance_double(RestClient::Resource, "hosts")
       )
 
-    allow(resource).to receive(:post).with(id: id).and_return(
+    allow(resource).to receive(:post).with({id: id}).and_return(
       instance_double(RestClient::Response, "host response", body: '
         {
           "id": "test-host",


### PR DESCRIPTION
### Desired Outcome

NOTE: The changes from this PR are also included in [PR 213](https://github.com/cyberark/conjur-api-ruby/pull/213) along with additional functionality to make POSt requests to the authenticator endpoint.

Currently, Conjur's Ruby API withholds detailed response information from users on most of its functions, only returning choice details after parsing a RestClient::Response object. This includes [functions responsible for submitting OIDC authentication requests](https://github.com/cyberark/conjur-api-ruby/blob/main/lib/conjur/api/authn.rb#L69).

Users of the Conjur Ruby API need a path for submitting OIDC authentication requests, and receiving in response the raw RestClient::Response object. Specifically, this would give the Ruby API user access to Conjur's response headers.

### Implemented Changes

* Turn `authenticator_authenticate` into a wrapper for parsing the access token response
* Add function which returns the raw response to the caller


### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
