### PR TITLE
OIDC post endpoint

### DIFF
--- a/features/authn.feature
+++ b/features/authn.feature
@@ -13,13 +13,24 @@ Feature: Authenticate with Conjur
     """
     Then the JSON should have "payload"
 
-  Scenario: Authenticate with OIDC code requesting unparsed result
+  Scenario: Authenticate with OIDC code requesting unparsed result via GET method
     When I retrieve the provider details for OIDC authenticator "keycloak"
     And I retrieve auth info for the OIDC provider with username: "alice" and password: "alice"
     And I run the code:
     """
     $conjur.authenticator_enable "authn-oidc", "keycloak"
     Conjur::API.authenticator_authenticate_get("authn-oidc", "keycloak", options: @auth_body)
+    """
+    Then the response body contains: "payload"
+    And the response includes headers
+
+  Scenario: Authenticate with OIDC code requesting unparsed result via POST method
+    When I retrieve the provider details for OIDC authenticator "keycloak"
+    And I retrieve auth info for the OIDC provider with username: "alice" and password: "alice"
+    And I run the code:
+    """
+    $conjur.authenticator_enable "authn-oidc", "keycloak"
+    Conjur::API.authenticator_authenticate_post("authn-oidc", "keycloak", options: @auth_body)
     """
     Then the response body contains: "payload"
     And the response includes headers

--- a/lib/conjur/api/authn.rb
+++ b/lib/conjur/api/authn.rb
@@ -63,7 +63,7 @@ module Conjur
       # @param [Hash] params Additional params to send to authenticator
       # @return [String] A JSON formatted authentication token.
       def authenticator_authenticate authenticator, service_id, account: Conjur.configuration.account, options: {}
-        JSON.parse authenticator_authenticate_get authenticator, service_id, account: account, options: options
+        JSON.parse authenticator_authenticate_post authenticator, service_id, account: account, options: options
       end
 
       # Authenticates using a third party authenticator like authn-oidc via GET request.
@@ -78,7 +78,23 @@ module Conjur
         if Conjur.log
           Conjur.log << "Authenticating to account #{account} using #{authenticator}/#{service_id}\n"
         end
-        url_for(:authenticator_authenticate, account, service_id, authenticator, options).get
+        url_for(:authenticator_authenticate_get, account, service_id, authenticator, options).get
+      end
+
+      # Authenticates using a third party authenticator like authn-oidc via POST request.
+      # It will return an response object containing access/refresh token data.
+      #
+      # @param [String] authenticator
+      # @param [String] service_id
+      # @param [String] account The organization account.
+      # @param [Hash] params Additional params to send to authenticator
+      # @return [RestClient::Response] Response object
+      def authenticator_authenticate_post authenticator, service_id, account: Conjur.configuration.account, options: {}
+        if Conjur.log
+          Conjur.log << "Authenticating to account #{account} using #{authenticator}/#{service_id}\n"
+        end
+        encoded_params = URI.encode_www_form(options)
+        url_for(:authenticator_authenticate_post, account, service_id, authenticator).post(encoded_params, content_type: 'application/www-url-form-encoded')
       end
 
       # Exchanges Conjur the API key (refresh token) for an access token.  The access token can

--- a/lib/conjur/api/router/v5.rb
+++ b/lib/conjur/api/router/v5.rb
@@ -43,11 +43,18 @@ module Conjur
           )[fully_escape account][fully_escape username]['authenticate']
         end
 
-        def authenticator_authenticate(account, service_id, authenticator, options)
+        def authenticator_authenticate_get(account, service_id, authenticator, options)
           RestClient::Resource.new(
             Conjur.configuration.core_url,
             Conjur.configuration.rest_client_options
           )[fully_escape authenticator][fully_escape service_id][fully_escape account]['authenticate'][options_querystring options]
+        end
+
+        def authenticator_authenticate_post(account, service_id, authenticator)
+          RestClient::Resource.new(
+            Conjur.configuration.core_url,
+            Conjur.configuration.rest_client_options
+          )[fully_escape authenticator][fully_escape service_id][fully_escape account]['authenticate']
         end
 
         def authenticator account, authenticator, service_id, credentials


### PR DESCRIPTION
### Desired Outcome

Extend the Conjur Ruby API to submit POST requests to the OIDC authentication endpoint.

This new function needs to be able to return a raw RestClient::Response object as it will be used for OIDC refresh token exchanged by Conjur UI.

### Implemented Changes

- Added POST routing and new function
- Make POST request the default behavior
- Added cucumber scenario

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
