### PR TITLE
Remove Ruby v2.7 tests, include tests for 3.1 and 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added authenticate wrapper to access unparsed response object (including headers).
   [cyberark/conjur-api-ruby#213](https://github.com/cyberark/conjur-api-ruby/pull/213)
+- Support Ruby v3.1 and v3.2.
+  [cyberark/conjur-api-ruby#220](https://github.com/cyberark/conjur-api-ruby/pull/220)
 
 ## [5.4.0] - 2022-08-16
 
@@ -381,7 +383,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.0.0] - 2013-13-12
 
-[Unreleased]: https://github.com/cyberark/conjur-api-ruby/compare/v5.4.0...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-api-ruby/compare/v5.4.1...HEAD
+[5.4.1]: https://github.com/cyberark/conjur-api-ruby/compare/v5.4.0...v5.4.1
 [5.4.0]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.7...v5.4.0
 [5.3.7]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.6...v5.3.7
 [5.3.6]: https://github.com/cyberark/conjur-api-ruby/compare/v5.3.5...v5.3.6

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,14 +58,13 @@ pipeline {
       }
     }
 
-    stage('Test Ruby 2.7') {
+    stage('Test Ruby 3.0') {
       environment {
-        RUBY_VERSION = '2.7'
+        RUBY_VERSION = '3.0'
       }
       steps {
-        sh './test.sh'
+        sh("./test.sh")
       }
-
       post {
         always {
           junit 'spec/reports/*.xml'
@@ -75,9 +74,25 @@ pipeline {
       }
     }
 
-    stage('Test Ruby 3.0') {
+    stage('Test Ruby 3.1') {
       environment {
-        RUBY_VERSION = '3.0'
+        RUBY_VERSION = '3.1'
+      }
+      steps {
+        sh("./test.sh")
+      }
+      post {
+        always {
+          junit 'spec/reports/*.xml'
+          junit 'features/reports/*.xml'
+          junit 'features_v4/reports/*.xml'
+        }
+      }
+    }
+
+    stage('Test Ruby 3.2') {
+      environment {
+        RUBY_VERSION = '3.2'
       }
       steps {
         sh("./test.sh")


### PR DESCRIPTION
### Desired Outcome

Test against only Ruby 3.0+

### Implemented Changes

- Remove Jenkins stage testing against Ruby 2.7
- Include Jenkins stage testing against Ruby 3.1
- Include Jenkins stage testing against Ruby 3.2
### Connected Issue/Story

CNJR-1433

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
