### PR TITLE
Use new AuthnOIDC ca-cert variable in test

### DIFF
--- a/ci/oauth/keycloak/fetch_certificate
+++ b/ci/oauth/keycloak/fetch_certificate
@@ -12,7 +12,3 @@ openssl s_client \
   openssl x509 \
     -outform PEM \
     >/etc/ssl/certs/keycloak.pem
-
-hash=$(openssl x509 -hash -in /etc/ssl/certs/keycloak.pem -out /dev/null)
-
-ln -s /etc/ssl/certs/keycloak.pem "/etc/ssl/certs/${hash}.0"

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -85,20 +85,19 @@ end
 
 Given(/^I setup a keycloak authenticator$/) do
     $conjur.load_policy 'root', <<-POLICY
-    - !policy 
+    - !policy
       id: conjur/authn-oidc/keycloak
-      body: 
-      - !webservice  
-     
-      - !variable provider-uri 
-      - !variable client-id 
-      - !variable client-secret 
+      body:
+      - !webservice
+
+      - !variable provider-uri
+      - !variable client-id
+      - !variable client-secret
       - !variable name
-     
-      - !variable claim-mapping 
-       
-      - !variable nonce 
+      - !variable claim-mapping
+      - !variable nonce
       - !variable state
+      - !variable ca-cert
 
       - !variable redirect-uri
 
@@ -122,6 +121,7 @@ Given(/^I setup a keycloak authenticator$/) do
     @nonce = $conjur.resource("cucumber:variable:conjur/authn-oidc/keycloak/nonce")
     @state = $conjur.resource("cucumber:variable:conjur/authn-oidc/keycloak/state")
     @redirect_uri = $conjur.resource("cucumber:variable:conjur/authn-oidc/keycloak/redirect-uri")
+    @ca_cert = $conjur.resource("cucumber:variable:conjur/authn-oidc/keycloak/ca-cert")
 
     @provider_uri.add_value "https://keycloak:8443/auth/realms/master"
     @client_id.add_value "conjurClient"
@@ -131,4 +131,5 @@ Given(/^I setup a keycloak authenticator$/) do
     @state.add_value SecureRandom.uuid
     @name.add_value "keycloak"
     @redirect_uri.add_value "http://conjur_5/authn-oidc/keycloak/cucumber/authenticate"
+    @ca_cert.add_value File.read("/etc/ssl/certs/keycloak.pem")
 end


### PR DESCRIPTION
### Desired Outcome

Fix failing Jenkins build. Logs:
```
12:59:24  Feature: List and manage authenticators

...

12:59:25    Scenario: Get a list of OIDC providers                   # features/authenticators.feature:36
12:59:25      When I run the code:                                   # features/step_definitions/api_steps.rb:1
12:59:25        """
12:59:25        $conjur.authentication_providers("authn-oidc")
12:59:25        """
12:59:25      Then the providers list contains service id "keycloak" # features/step_definitions/result_steps.rb:9
12:59:25        expected [] to include "keycloak" (RSpec::Expectations::ExpectationNotMetError)
12:59:25        ./features/step_definitions/result_steps.rb:10:in `/^the providers list contains service id "([^"]+)"$/'
12:59:25        features/authenticators.feature:41:in `Then the providers list contains service id "keycloak"'
12:59:25  
12:59:25  Feature: Authenticate with Conjur
12:59:25  
12:59:25    Background:                              # features/authn.feature:3
12:59:25      Given I setup a keycloak authenticator # features/step_definitions/policy_steps.rb:86
12:59:25  
12:59:25    Scenario: Authenticate with OIDC code                                                         # features/authn.feature:6
12:59:25      When I retrieve the provider details for OIDC authenticator "keycloak"                      # features/step_definitions/api_steps.rb:20
12:59:25        undefined method `[]' for nil:NilClass (NoMethodError)
12:59:25        ./features/step_definitions/api_steps.rb:22:in `/^I retrieve the provider details for OIDC authenticator "([^"]+)"$/'
12:59:25        features/authn.feature:7:in `When I retrieve the provider details for OIDC authenticator "keycloak"'
12:59:25      And I retrieve auth info for the OIDC provider with username: "alice" and password: "alice" # features/step_definitions/api_steps.rb:28
12:59:25      And I run the code:                                                                         # features/step_definitions/api_steps.rb:1
12:59:25        """
12:59:25        $conjur.authenticator_enable "authn-oidc", "keycloak"
12:59:25        Conjur::API.authenticator_authenticate("authn-oidc", "keycloak", options: @auth_body)
12:59:25        """
12:59:25      Then the JSON should have "payload"                                                         # json_spec-1.1.5/lib/json_spec/cucumber.rb:73
12:59:25  
12:59:26    Scenario: Authenticate with OIDC code requesting unparsed result                              # features/authn.feature:16
12:59:26      When I retrieve the provider details for OIDC authenticator "keycloak"                      # features/step_definitions/api_steps.rb:20
12:59:26        undefined method `[]' for nil:NilClass (NoMethodError)
12:59:26        ./features/step_definitions/api_steps.rb:22:in `/^I retrieve the provider details for OIDC authenticator "([^"]+)"$/'
12:59:26        features/authn.feature:17:in `When I retrieve the provider details for OIDC authenticator "keycloak"'
12:59:26      And I retrieve auth info for the OIDC provider with username: "alice" and password: "alice" # features/step_definitions/api_steps.rb:28
12:59:26      And I run the code:                                                                         # features/step_definitions/api_steps.rb:1
12:59:26        """
12:59:26        $conjur.authenticator_enable "authn-oidc", "keycloak"
12:59:26        Conjur::API.authenticator_authenticate_get("authn-oidc", "keycloak", options: @auth_body)
12:59:26        """
12:59:26      Then the response body contains: "payload"                                                  # features/step_definitions/api_steps.rb:56
12:59:26      And the response includes headers                                                           # features/step_definitions/api_steps.rb:60
```

### Implemented Changes

Use AuthnOIDC's new `ca-cert` variable instead of certificates included in the container's default certificate store.

**NOTE:** this update is not _required_ for this flow to work. The new `ca-cert` variable does not break the previous strategy. The reason these tests failed was a faulty `openssl` command:

```diff
- openssl x509 -hash -in /etc/ssl/certs/keycloak.pem -out /dev/null
+ openssl x509 -hash -in /etc/ssl/certs/keycloak.pem --noout
```

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
